### PR TITLE
removeAll for collections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Issues and Pull Requests are welcome. This project is particular because it does not stick to some JS conventions, but the purpose is not that, but having a consistent way of teaching OO in a more pure way. Changes aligned with this philosophy can be integrated.
 
-If you add a new feature, please add a unit test for it on the `test/extensions` folder if it's an extension, or `test/objects` if it is a new object.
+For any type of code change where behavior is affected (a new feature or a bug fix), please add a unit test for it on the `test/extensions` folder if it's an extension of an existing JS object, or `test/objects` if it about a new object.
 
-Using [Gitmoji](https://gitmoji.carloscuesta.me/) is a nice-to have :)
+For new features, please include a documentation in our README files.
+
+Using [Gitmoji](https://gitmoji.carloscuesta.me/) to format your commit messages s a nice-to have :)

--- a/src/extensions/collections.js
+++ b/src/extensions/collections.js
@@ -120,6 +120,10 @@ const HeterogeneousCollection = {
       });
       return result;
     },
+
+    removeAll() {
+      return this.clear();
+    }
   },
 };
 
@@ -149,6 +153,10 @@ const ArrayExtensions = {
         if (this[i] !== array[i]) return false;
       }
       return true;
+    },
+
+    clear() {
+      this.length = 0;
     },
   },
 };

--- a/tests/extensions/collection_extension_test.js
+++ b/tests/extensions/collection_extension_test.js
@@ -285,15 +285,35 @@ suite('messages added to Array, String and Set', () => {
   });
   
   test('atRandom() for all collections, when the collection is empty it returns undefined', () => {
-    // refactor when isUndefined() matcher is added to testy
-    assert.isTrue(''.atRandom() === undefined);
-    assert.isTrue([].atRandom() === undefined);
-    assert.isTrue(Set.with().atRandom() === undefined);
+    assert.isUndefined(''.atRandom());
+    assert.isUndefined([].atRandom());
+    assert.isUndefined(Set.with().atRandom());
   });
   
   test('atRandom() and sample() are aliases', () => {
     assert.areEqual('h'.atRandom(), 'h'.sample());
     assert.areEqual([1].atRandom(), [1].sample());
     assert.areEqual(Set.with(3).atRandom(), Set.with(3).sample());
+  });
+
+  test('removeAll() for array', () => {
+    const array = ['a', 2, { b: 3 }];
+    array.removeAll();
+
+    assert.that(array).isEmpty();
+  });
+
+  test('removeAll() for set', () => {
+    const set = Set.with(1, 2, 3);
+    set.removeAll();
+
+    assert.that(set).isEmpty();
+  });
+
+  test('clear() for array', () => {
+    const array = ['a', 2, { b: 3 }];
+    array.clear();
+
+    assert.that(array).isEmpty();
   });
 });


### PR DESCRIPTION
See #23 .

Also adding `clear()` to `Array` because it is already in `Set` and `Map` and this increases polymorphism.